### PR TITLE
fix HBM switch issue

### DIFF
--- a/cmhw/org/cyanogenmod/hardware/SunlightEnhancement.java
+++ b/cmhw/org/cyanogenmod/hardware/SunlightEnhancement.java
@@ -75,7 +75,7 @@ public class SunlightEnhancement {
             return LiveDisplayVendorImpl.native_setOutdoorModeEnabled(status);
         }
 
-        return FileUtils.writeLine(FILE_SRE, status ? "2" : "0");
+        return FileUtils.writeLine(FILE_SRE, status ? "1" : "0");
     }
 
     /**


### PR DESCRIPTION
The HBM is a switch, so, the accepted kernel values are 1 or 0.
public static boolean setEnabled(boolean status) { if (sHasNativeSupport) { return LiveDisplayVendorImpl.native_setOutdoorModeEnabled(status); } return FileUtils.writeLine(FILE_SRE, status ? "2" : "0"); <---- HERE should be "1" : "0" ----> }
Thanks

Change-Id: Ibf7052af088750b72f8292ee1b4182824edaf86f
